### PR TITLE
v1.0.2

### DIFF
--- a/LIS3MDL.class.nut
+++ b/LIS3MDL.class.nut
@@ -4,7 +4,7 @@
 
 class LIS3MDL {
 
-    static VERSION = [1,0,1];
+    static VERSION = [1,0,2];
 
     // External constants
     static AXIS_X = 0x80;
@@ -179,7 +179,7 @@ class LIS3MDL {
             "y_negative" : interruptByte & 0x08 ? true : false,
             "z_negative" : interruptByte & 0x04 ? true : false,
             "overflow"   : interruptByte & 0x02 ? true : false,
-            "interrupt"  : interruptByte & 0x01 ? true : false
+            "interrupt"  : interruptByte & 0x01
         };
 
         return statusTable;

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Creates and initializes an object representing the LIS3MDL magnetometer.  Note t
 ### Usage
 
 ```squirrel
-#require "LIS3MDL.class.nut:1.0.1"
+#require "LIS3MDL.class.nut:1.0.2"
 
 local i2c = hardware.i2c89;
 i2c.configure(CLOCK_SPEED_400_KHZ);
@@ -264,7 +264,7 @@ magnetometer.configureInterrupt(false);
 
 Parses and returns the interrupt source register on the LIS3MDL.
 
-The return value is a Squirrel table with following keys and booleans as values:
+The return value is a Squirrel table with following keys and booleans or values:
 
 | Key        | Description                                                   |
 |------------|---------------------------------------------------------------|
@@ -275,7 +275,7 @@ The return value is a Squirrel table with following keys and booleans as values:
 | z_positive | The Z-axis value exceeded the threshold on the positive side. |
 | z_negative | The Z-axis value exceeded the threshold on the negative side. |
 | overflow   | A value overflowed the internal measurement range.            |
-| interrupt  | An interrupt event has occured (value always matches interrupt pin state) |
+| interrupt  | Value is the interrupt pin state.  |
 
 ## readAxes([*callback*])
 


### PR DESCRIPTION
Showing a boolean value based only on pin state (0-false, 1-true) for an interrupt that is usually configured active low was not clear.  Now the table shows the pin state, allowing the user to determine interrupt status.  
Version numbers updated. 
